### PR TITLE
Fix OAuth scope for Amazon Creators API

### DIFF
--- a/app/auth.py
+++ b/app/auth.py
@@ -33,7 +33,7 @@ def _fetch_token():
             "grant_type":    "client_credentials",
             "client_id":     config.CREATORS_CREDENTIAL_ID,
             "client_secret": config.CREATORS_CREDENTIAL_SECRET,
-            "scope":         "advertising::audiences",
+            "scope":         "creatorsapi/default",
         },
         timeout=15,
     )


### PR DESCRIPTION
זה היה הבאג. ב-`app/auth.py:36` ה-scope היה `"advertising::audiences"` (של Amazon Advertising API), בעוד שה-Creators API צריך `"creatorsapi/default"`.

מצאתי את ה-scope הנכון מתוך [ספריית apaapi](https://github.com/Jakiboy/apaapi) שמממשת את ה-OAuth של Creators API — `src/lib/OAuth.php` שורה 151.


The scope was "advertising::audiences" (Amazon Advertising API) but should be "creatorsapi/default" for the Creators API. This caused a 400 Bad Request on every token fetch.

Reference: https://github.com/Jakiboy/apaapi (src/lib/OAuth.php)

https://claude.ai/code/session_01UeEcKiCAqx7s7PdUQ61Nio