### PR TITLE
Fix OAuth token URL — use Cognito endpoints per API version

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -22,8 +22,15 @@ PRICE_DROP_PERCENT = 0.05   # 5%
 
 # API
 CREATORS_API_BASE  = "https://affiliate-program.amazon.com/api/v1"
-TOKEN_URL          = "https://api.amazon.com/auth/o2/token"
 MARKETPLACE        = "www.amazon.com"
+
+# Creators API OAuth token endpoint — varies by credential version (region)
+_TOKEN_ENDPOINTS = {
+    "2.1": "https://creatorsapi.auth.us-east-1.amazoncognito.com/oauth2/token",   # NA
+    "2.2": "https://creatorsapi.auth.eu-south-2.amazoncognito.com/oauth2/token",   # EU
+    "2.3": "https://creatorsapi.auth.us-west-2.amazoncognito.com/oauth2/token",    # FE
+}
+TOKEN_URL = _TOKEN_ENDPOINTS.get(CREATORS_VERSION, _TOKEN_ENDPOINTS["2.1"])
 
 # Telegram disclaimer text (sent as second message)
 DISCLAIMER_TEXT = (


### PR DESCRIPTION
הנה הבעיה! **גם ה-URL שגוי**. ה-Creators API לא משתמש ב-`api.amazon.com/auth/o2/token` אלא ב-**Amazon Cognito endpoints** שתלויים בגרסה:

| Version | Region | Token URL |
|---------|--------|-----------|
| 2.1 | NA (צפון אמריקה) | `https://creatorsapi.auth.us-east-1.amazoncognito.com/oauth2/token` |
| 2.2 | EU (אירופה) | `https://creatorsapi.auth.eu-south-2.amazoncognito.com/oauth2/token` |
| 2.3 | FE (מזרח רחוק) | `https://creatorsapi.auth.us-west-2.amazoncognito.com/oauth2/token` |


The Creators API uses regional Amazon Cognito token endpoints, not the old api.amazon.com/auth/o2/token (which returns invalid_scope).

Version → endpoint mapping:
  2.1 → us-east-1  (NA)
  2.2 → eu-south-2 (EU)
  2.3 → us-west-2  (FE)

Token URL is now resolved dynamically from CREATORS_API_VERSION.

https://claude.ai/code/session_01UeEcKiCAqx7s7PdUQ61Nio