### PR TITLE
Add OAuth fallback strategies for v3.1 credentials

### DIFF
--- a/app/auth.py
+++ b/app/auth.py
@@ -5,6 +5,10 @@ from app import db, config
 
 logger = logging.getLogger(__name__)
 
+# Fallback token endpoints to try when the primary Cognito endpoint fails.
+# v3.1 credentials may use a different OAuth provider.
+_LWA_TOKEN_URL = "https://api.amazon.com/auth/o2/token"
+
 
 def get_valid_token() -> str:
     """
@@ -26,25 +30,67 @@ def get_valid_token() -> str:
     return token
 
 
-def _fetch_token():
+def _mask(value: str) -> str:
+    return (value[:4] + "...") if value else "<empty>"
+
+
+def _try_cognito_basic(url: str, cid: str, secret: str) -> requests.Response:
+    """Strategy 1: Cognito with HTTP Basic Auth (works for v2.x credentials)."""
+    payload = {"grant_type": "client_credentials", "scope": "creatorsapi/default"}
+    return requests.post(url, data=payload, auth=(cid, secret), timeout=15)
+
+
+def _try_cognito_body(url: str, cid: str, secret: str) -> requests.Response:
+    """Strategy 2: Cognito with credentials in POST body (client_secret_post)."""
     payload = {
         "grant_type": "client_credentials",
-        "scope":      "creatorsapi/default",
+        "scope": "creatorsapi/default",
+        "client_id": cid,
+        "client_secret": secret,
     }
-    # Cognito requires client credentials via HTTP Basic Auth
-    auth = (config.CREATORS_CREDENTIAL_ID, config.CREATORS_CREDENTIAL_SECRET)
+    return requests.post(url, data=payload, timeout=15)
 
-    # Debug: log what we're sending (mask the secret)
-    masked_id = config.CREATORS_CREDENTIAL_ID[:4] + "..." if config.CREATORS_CREDENTIAL_ID else "<empty>"
-    masked_secret = config.CREATORS_CREDENTIAL_SECRET[:4] + "..." if config.CREATORS_CREDENTIAL_SECRET else "<empty>"
+
+def _try_lwa(cid: str, secret: str) -> requests.Response:
+    """Strategy 3: Login With Amazon endpoint (may be needed for v3.x credentials)."""
+    payload = {
+        "grant_type": "client_credentials",
+        "client_id": cid,
+        "client_secret": secret,
+        "scope": "creatorsapi/default",
+    }
+    return requests.post(_LWA_TOKEN_URL, data=payload, timeout=15)
+
+
+def _fetch_token():
+    cid = config.CREATORS_CREDENTIAL_ID
+    secret = config.CREATORS_CREDENTIAL_SECRET
+    url = config.TOKEN_URL
+
+    strategies = [
+        ("Cognito+BasicAuth", lambda: _try_cognito_basic(url, cid, secret)),
+        ("Cognito+BodyParams", lambda: _try_cognito_body(url, cid, secret)),
+        ("LWA", lambda: _try_lwa(cid, secret)),
+    ]
+
     logger.info(
-        "OAuth request → url=%s  client_id=%s  client_secret=%s  scope=%s",
-        config.TOKEN_URL, masked_id, masked_secret, payload["scope"],
+        "OAuth request → url=%s  client_id=%s  client_secret=%s",
+        url, _mask(cid), _mask(secret),
     )
 
-    resp = requests.post(config.TOKEN_URL, data=payload, auth=auth, timeout=15)
-    if not resp.ok:
-        logger.error("OAuth response %s: %s", resp.status_code, resp.text)
-    resp.raise_for_status()
-    data = resp.json()
-    return data["access_token"], int(data.get("expires_in", 3600))
+    last_resp = None
+    for name, strategy in strategies:
+        resp = strategy()
+        if resp.ok:
+            data = resp.json()
+            logger.info("OAuth succeeded with strategy: %s", name)
+            return data["access_token"], int(data.get("expires_in", 3600))
+        logger.warning(
+            "OAuth strategy %s failed (%s): %s", name, resp.status_code, resp.text
+        )
+        last_resp = resp
+
+    # All strategies failed — raise the last error
+    logger.error("All OAuth strategies exhausted. Last response: %s %s",
+                 last_resp.status_code, last_resp.text)
+    last_resp.raise_for_status()


### PR DESCRIPTION
עדכנתי את הקוד. עכשיו כשהבוט מנסה להתחבר, הוא ינסה **3 שיטות אוטומטית**:

1. **Cognito + Basic Auth** — השיטה הישנה (עובד ל-v2.x)
2. **Cognito + Body Params** — אותו endpoint, credentials בגוף הבקשה
3. **Login With Amazon** — `api.amazon.com/auth/o2/token` (אם אמזון העביר v3.1 לשם)

הבוט ינסה כל שיטה ברצף, ויעצור ברגע שאחת מצליחה. בלוג יהיה כתוב איזו שיטה עבדה.

**עדכן את Render** (deploy) ותבדוק את הלוגים — נראה איזו שיטה מצליחה, או אם כל השלוש נכשלות נדע בדיוק מה הבעיה.


When the primary Cognito+BasicAuth method fails, automatically try:
1. Cognito with credentials in POST body (client_secret_post)
2. Login With Amazon endpoint (api.amazon.com/auth/o2/token)

This handles the case where v3.1 credentials may use a different OAuth provider or authentication method than v2.x credentials.

https://claude.ai/code/session_01UeEcKiCAqx7s7PdUQ61Nio