### PR TITLE
Fix API endpoint for Creators API: use creatorsapi.amazon host

### DIFF
--- a/app/auth.py
+++ b/app/auth.py
@@ -90,9 +90,10 @@ def _fetch_token():
 
     strategies = _build_strategies(url, cid, secret, version)
 
+    effective_url = _LWA_TOKEN_URL if not version.startswith("2.") else url
     logger.info(
         "OAuth request → version=%s  url=%s  client_id=%s  client_secret=%s",
-        version, url, _mask(cid), _mask(secret),
+        version, effective_url, _mask(cid), _mask(secret),
     )
 
     last_resp = None

--- a/app/creators_client.py
+++ b/app/creators_client.py
@@ -5,7 +5,7 @@ from app import config
 
 logger = logging.getLogger(__name__)
 
-_BASE = "https://affiliate-program.amazon.com/api/v1"
+_BASE = "https://creatorsapi.amazon/catalog/v1"
 
 _ITEM_RESOURCES = [
     "ItemInfo.Title",
@@ -20,9 +20,11 @@ _SEARCH_RESOURCES = _ITEM_RESOURCES[:]
 
 
 def _headers(token):
+    version = config.CREATORS_VERSION
     return {
-        "Authorization": f"Bearer {token}",
+        "Authorization": f"Bearer {token}, Version {version}",
         "Content-Type":  "application/json",
+        "x-marketplace": config.MARKETPLACE,
     }
 
 


### PR DESCRIPTION
עדכנתי 3 דברים:

1. **Base URL** → `https://creatorsapi.amazon/catalog/v1`
2. **Authorization header** → `Bearer {token}, Version {version}`
3. **הוספתי header** → `x-marketplace: www.amazon.com`

עדכן את Render ושלח לי לוגים. הפעם ה-authentication עובד, אז נראה אם גם ה-API calls עוברים.

- Change base URL from affiliate-program.amazon.com/api/v1 to creatorsapi.amazon/catalog/v1
- Add x-marketplace header required by Creators API
- Add Version to Authorization header: "Bearer {token}, Version {ver}"
- Fix auth log to show correct URL for v3.x strategies

https://claude.ai/code/session_01UeEcKiCAqx7s7PdUQ61Nio