### PR TITLE
Fix resource names to lowerCamelCase for Creators API

### DIFF
--- a/app/creators_client.py
+++ b/app/creators_client.py
@@ -8,12 +8,11 @@ logger = logging.getLogger(__name__)
 _BASE = "https://creatorsapi.amazon/catalog/v1"
 
 _ITEM_RESOURCES = [
-    "ItemInfo.Title",
-    "Images.Primary.Medium",
-    "DetailPageURL",
-    "OffersV2.Listings.Price",
-    "OffersV2.Listings.Availability",
-    "OffersV2.Listings.MerchantInfo",
+    "itemInfo.title",
+    "images.primary.medium",
+    "offersV2.listings.price",
+    "offersV2.listings.availability",
+    "offersV2.listings.merchantInfo",
 ]
 
 _SEARCH_RESOURCES = _ITEM_RESOURCES[:]


### PR DESCRIPTION
עדכן את Render ונראה אם הפעם ה-SearchItems מצליח. תיקנו:

1. ~~Authentication~~ (LWA endpoint + scope)
2. ~~API endpoint~~ (`creatorsapi.amazon/catalog/v1`)
3. ~~Headers~~ (`x-marketplace`, `Bearer + Version`)
4. ~~Resource names~~ (lowerCamelCase)

שלח לי את הלוגים אחרי ה-deploy!

Resource enum values changed from PascalCase (PA-API) to lowerCamelCase (Creators API): itemInfo.title, images.primary.medium, offersV2.listings.price/availability/merchantInfo. Removed DetailPageURL (auto-included in response).

https://claude.ai/code/session_01UeEcKiCAqx7s7PdUQ61Nio