### PR TITLE
Fix OAuth: route v3.1 through Cognito instead of LWA

### DIFF
--- a/app/auth.py
+++ b/app/auth.py
@@ -5,8 +5,6 @@ from app import db, config
 
 logger = logging.getLogger(__name__)
 
-_LWA_TOKEN_URL = "https://api.amazon.com/auth/o2/token"
-
 
 def get_valid_token() -> str:
     """
@@ -44,37 +42,26 @@ def _post_safe(url: str, **kwargs) -> requests.Response | None:
 def _build_strategies(url: str, cid: str, secret: str, version: str):
     """
     Build an ordered list of (name, callable) auth strategies.
-    v2.x → Cognito (body credentials first, Basic Auth fallback).
-    v3.x → LWA endpoint with client_credentials grant.
+    All versions use the Cognito endpoint with creatorsapi/default scope.
     """
     strategies = []
 
-    if version.startswith("2."):
-        # v2.x: Cognito — body credentials (official SDK), then Basic Auth
-        strategies.append(("Cognito+BodyCredentials", lambda: _post_safe(
-            url,
-            data={
-                "grant_type": "client_credentials",
-                "client_id": cid,
-                "client_secret": secret,
-                "scope": "creatorsapi/default",
-            },
-        )))
-        strategies.append(("Cognito+BasicAuth", lambda: _post_safe(
-            url,
-            data={"grant_type": "client_credentials", "scope": "creatorsapi/default"},
-            auth=(cid, secret),
-        )))
-    else:
-        # v3.x: LWA endpoint — client_credentials in body
-        strategies.append(("LWA+ClientCredentials", lambda: _post_safe(
-            _LWA_TOKEN_URL,
-            data={
-                "grant_type": "client_credentials",
-                "client_id": cid,
-                "client_secret": secret,
-            },
-        )))
+    # All versions (2.x and 3.x) use the Cognito endpoint with creatorsapi scope.
+    # The correct Cognito URL is resolved per-version in config._TOKEN_ENDPOINTS.
+    strategies.append(("Cognito+BodyCredentials", lambda: _post_safe(
+        url,
+        data={
+            "grant_type": "client_credentials",
+            "client_id": cid,
+            "client_secret": secret,
+            "scope": "creatorsapi/default",
+        },
+    )))
+    strategies.append(("Cognito+BasicAuth", lambda: _post_safe(
+        url,
+        data={"grant_type": "client_credentials", "scope": "creatorsapi/default"},
+        auth=(cid, secret),
+    )))
 
     return strategies
 
@@ -87,10 +74,9 @@ def _fetch_token():
 
     strategies = _build_strategies(url, cid, secret, version)
 
-    effective_url = _LWA_TOKEN_URL if not version.startswith("2.") else url
     logger.info(
         "OAuth request → version=%s  url=%s  client_id=%s  client_secret=%s",
-        version, effective_url, _mask(cid), _mask(secret),
+        version, url, _mask(cid), _mask(secret),
     )
 
     last_resp = None


### PR DESCRIPTION
נדחף. הנה מה שהיה:

**הבעיה**: גרסה `3.1` לא מתחילה ב-`"2."`, אז הקוד שלח את בקשת ה-token ל-**LWA endpoint** (`api.amazon.com/auth/o2/token`) במקום ל-**Cognito**. LWA לא מכיר את scope `creatorsapi/default` והחזיר "missing required parameter: scope".

**התיקון**: ב-`config.py` שורה 9 כבר הגדרת ש-`3.1` משתמש באותו Cognito endpoint כמו `2.1`. עכשיו `auth.py` שולח **את כל הגרסאות** דרך Cognito עם `scope: creatorsapi/default` — בדיוק כמו שצריך.

תעשה deploy מחדש ותבדוק.


v3.1 credentials use the same Cognito endpoint as v2.1 (NA region). The previous code incorrectly routed v3.x to the LWA endpoint (api.amazon.com/auth/o2/token) which requires a different scope and returned "missing required parameter: scope" errors.

Now all versions use the Cognito endpoint with creatorsapi/default scope.

https://claude.ai/code/session_01UeEcKiCAqx7s7PdUQ61Nio