### PR TITLE
Fix v3.x OAuth: try Cognito first, LWA fallback; fix datetime depreca…

### DIFF
--- a/app/auth.py
+++ b/app/auth.py
@@ -1,6 +1,6 @@
 import requests
 import logging
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from app import db, config
 
 logger = logging.getLogger(__name__)
@@ -16,13 +16,13 @@ def get_valid_token() -> str:
     """
     cached = db.get_token_cache()
     if cached:
-        expires_at = datetime.fromisoformat(cached["expires_at"])
-        if datetime.utcnow() < expires_at - timedelta(minutes=5):
+        expires_at = datetime.fromisoformat(cached["expires_at"]).replace(tzinfo=timezone.utc)
+        if datetime.now(timezone.utc) < expires_at - timedelta(minutes=5):
             return cached["access_token"]
 
     logger.info("Fetching new OAuth token...")
     token, expires_in = _fetch_token()
-    expires_at = datetime.utcnow() + timedelta(seconds=expires_in)
+    expires_at = datetime.now(timezone.utc) + timedelta(seconds=expires_in)
     db.set_token_cache(token, expires_at.isoformat())
     logger.info("New token cached, expires at %s", expires_at.isoformat())
     return token
@@ -45,40 +45,39 @@ def _build_strategies(url: str, cid: str, secret: str, version: str):
     """
     Build an ordered list of (name, callable) auth strategies.
     v2.x → Cognito endpoint (body creds, then Basic Auth).
-    v3.x → LWA endpoint with creatorsapi/default scope.
+    v3.x → Cognito first (same scope), then LWA fallback (no scope).
     """
     strategies = []
 
-    if version.startswith("2."):
-        # v2.x: Cognito endpoint
-        strategies.append(("Cognito+BodyCredentials", lambda: _post_safe(
-            url,
-            data={
-                "grant_type": "client_credentials",
-                "client_id": cid,
-                "client_secret": secret,
-                "scope": "creatorsapi/default",
-            },
-        )))
-        strategies.append(("Cognito+BasicAuth", lambda: _post_safe(
-            url,
-            data={"grant_type": "client_credentials", "scope": "creatorsapi/default"},
-            auth=(cid, secret),
-        )))
-    else:
-        # v3.x: LWA endpoint with creatorsapi scope
+    # All versions: try Cognito with creatorsapi/default scope first
+    strategies.append(("Cognito+BodyCredentials", lambda: _post_safe(
+        url,
+        data={
+            "grant_type": "client_credentials",
+            "client_id": cid,
+            "client_secret": secret,
+            "scope": "creatorsapi/default",
+        },
+    )))
+    strategies.append(("Cognito+BasicAuth", lambda: _post_safe(
+        url,
+        data={"grant_type": "client_credentials", "scope": "creatorsapi/default"},
+        auth=(cid, secret),
+    )))
+
+    if not version.startswith("2."):
+        # v3.x: also try LWA as fallback (no scope for client_credentials)
         strategies.append(("LWA+BodyCredentials", lambda: _post_safe(
             _LWA_TOKEN_URL,
             data={
                 "grant_type": "client_credentials",
                 "client_id": cid,
                 "client_secret": secret,
-                "scope": "creatorsapi/default",
             },
         )))
         strategies.append(("LWA+BasicAuth", lambda: _post_safe(
             _LWA_TOKEN_URL,
-            data={"grant_type": "client_credentials", "scope": "creatorsapi/default"},
+            data={"grant_type": "client_credentials"},
             auth=(cid, secret),
         )))
 
@@ -93,10 +92,9 @@ def _fetch_token():
 
     strategies = _build_strategies(url, cid, secret, version)
 
-    effective_url = _LWA_TOKEN_URL if not version.startswith("2.") else url
     logger.info(
         "OAuth request → version=%s  url=%s  client_id=%s  client_secret=%s",
-        version, effective_url, _mask(cid), _mask(secret),
+        version, url, _mask(cid), _mask(secret),
     )
 
     last_resp = None

--- a/app/db.py
+++ b/app/db.py
@@ -1,6 +1,6 @@
 import sqlite3
 import os
-from datetime import datetime
+from datetime import datetime, timezone
 
 DB_PATH = os.getenv("DB_PATH", "bot.db")
 
@@ -49,7 +49,7 @@ def init_db():
 # ── Products ──────────────────────────────────────────────────────────────────
 
 def upsert_product(asin, title, image_url, product_url):
-    now = datetime.utcnow().isoformat()
+    now = datetime.now(timezone.utc).isoformat()
     with get_conn() as conn:
         conn.execute("""
             INSERT INTO products (asin, title, image_url, product_url, added_at, last_seen_in_catalog)
@@ -81,7 +81,7 @@ def get_state(asin):
 
 
 def update_state(asin, in_stock, price_usd):
-    now = datetime.utcnow().isoformat()
+    now = datetime.now(timezone.utc).isoformat()
     with get_conn() as conn:
         conn.execute("""
             INSERT INTO product_state (asin, last_in_stock, last_price_usd, last_checked_at)
@@ -94,7 +94,7 @@ def update_state(asin, in_stock, price_usd):
 
 
 def mark_restock_alert(asin):
-    now = datetime.utcnow().isoformat()
+    now = datetime.now(timezone.utc).isoformat()
     with get_conn() as conn:
         conn.execute(
             "UPDATE product_state SET last_restock_alert_at=? WHERE asin=?", (now, asin)
@@ -102,7 +102,7 @@ def mark_restock_alert(asin):
 
 
 def mark_price_alert(asin):
-    now = datetime.utcnow().isoformat()
+    now = datetime.now(timezone.utc).isoformat()
     with get_conn() as conn:
         conn.execute(
             "UPDATE product_state SET last_price_alert_at=? WHERE asin=?", (now, asin)
@@ -118,7 +118,7 @@ def get_fx_rate():
 
 
 def set_fx_rate(rate):
-    now = datetime.utcnow().isoformat()
+    now = datetime.now(timezone.utc).isoformat()
     with get_conn() as conn:
         conn.execute("""
             INSERT INTO fx_cache (id, usd_ils_rate, fetched_at) VALUES (1, ?, ?)

--- a/app/fx.py
+++ b/app/fx.py
@@ -1,6 +1,6 @@
 import requests
 import logging
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from app import db
 
 logger = logging.getLogger(__name__)
@@ -17,8 +17,8 @@ def get_usd_ils_rate() -> float:
     """
     cached = db.get_fx_rate()
     if cached:
-        fetched_at = datetime.fromisoformat(cached["fetched_at"])
-        if datetime.utcnow() - fetched_at < timedelta(hours=_CACHE_HOURS):
+        fetched_at = datetime.fromisoformat(cached["fetched_at"]).replace(tzinfo=timezone.utc)
+        if datetime.now(timezone.utc) - fetched_at < timedelta(hours=_CACHE_HOURS):
             return float(cached["usd_ils_rate"])
 
     try:

--- a/main.py
+++ b/main.py
@@ -16,7 +16,7 @@ import os
 import signal
 import threading
 import time
-from datetime import datetime
+from datetime import datetime, timezone
 
 logging.basicConfig(
     level  = logging.INFO,
@@ -69,10 +69,10 @@ def _bot_loop():
     logger.info("FX rate loaded: 1 USD = %.4f ILS", rate)
 
     _bot_initialised = True
-    last_catalog_refresh = datetime.min
+    last_catalog_refresh = datetime.min.replace(tzinfo=timezone.utc)
 
     while True:
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
 
         # ── Catalog refresh (every N hours) ────────────────────────────
         hours_since_refresh = (now - last_catalog_refresh).total_seconds() / 3600


### PR DESCRIPTION
נעשה ונדחף. סיכום השינויים:

**הבאג העיקרי** — `auth.py` שורה 68: עבור v3.x, הקוד דילג על Cognito ושלח ישר ל-LWA עם scope `creatorsapi/default`. אבל LWA לא מכיר את ה-scope הזה → `invalid_scope`.

**הפתרון:**
1. **v3.x עכשיו מנסה Cognito קודם** (בדיוק כמו v2.x) עם scope `creatorsapi/default` — זה ה-endpoint הנכון שכבר היה מוגדר ב-`config.py`
2. **LWA כ-fallback** בלי scope (לא רלוונטי ל-LWA client_credentials)
3. תיקון `_build_strategies` — עכשיו משתמש בפרמטר `url` לכל הגרסאות (תיקון הבאג שה-cursor bot זיהה)
4. תיקון כל ה-`datetime.utcnow()` → `datetime.now(timezone.utc)` (4 קבצים)

**מה לצפות בלוגים אחרי deploy:**
- אם ה-credentials תקינים ב-Cognito → `OAuth succeeded with strategy: Cognito+BodyCredentials`
- אם Cognito נותן `invalid_client` → ינסה `Cognito+BasicAuth`, ואז LWA fallbacks
- אם כלום לא עובד → ייתכן שצריך ליצור credentials חדשים ב-Associates Central

…tions

- v3.x credentials now try Cognito endpoint first (using the configured URL from config.py) instead of skipping straight to LWA. This fixes the invalid_scope error since creatorsapi/default is a Cognito scope.
- LWA fallback for v3.x omits the scope param (not valid for LWA).
- Replace all datetime.utcnow() with datetime.now(timezone.utc) to fix DeprecationWarning across auth.py, db.py, fx.py, and main.py.
- Fix timezone-aware/naive comparison in cache expiry checks.

https://claude.ai/code/session_01UeEcKiCAqx7s7PdUQ61Nio