### PR TITLE
Creators API authentication

### DIFF
--- a/app/auth.py
+++ b/app/auth.py
@@ -1,5 +1,7 @@
 import requests
 import logging
+import re
+import unicodedata
 from datetime import datetime, timedelta, timezone
 from app import db, config
 
@@ -38,6 +40,20 @@ def _mask(value: str) -> str:
 
 
 _FORM_HEADERS = {"Content-Type": "application/x-www-form-urlencoded"}
+
+# Some copy/paste sources (especially RTL languages) insert invisible Unicode
+# marks or non-breaking spaces. Cognito then treats credentials as different
+# strings and responds with {"error":"invalid_client"}.
+_CRED_SANITIZE_RE = re.compile(
+    r"[\s\u00A0\u200B\u200C\u200D\u200E\u200F\u202A-\u202E\u2066-\u2069\uFEFF]+"
+)
+
+
+def _sanitize_credential(value: str) -> str:
+    if value is None:
+        return ""
+    value = unicodedata.normalize("NFKC", str(value))
+    return _CRED_SANITIZE_RE.sub("", value)
 
 
 def _post_safe(url: str, **kwargs) -> requests.Response | None:
@@ -96,8 +112,17 @@ def _build_strategies(primary_url: str, cid: str, secret: str):
 
 
 def _fetch_token():
-    cid = config.CREATORS_CREDENTIAL_ID.strip()
-    secret = config.CREATORS_CREDENTIAL_SECRET.strip()
+    raw_cid = config.CREATORS_CREDENTIAL_ID
+    raw_secret = config.CREATORS_CREDENTIAL_SECRET
+
+    cid = _sanitize_credential(raw_cid)
+    secret = _sanitize_credential(raw_secret)
+
+    if cid != str(raw_cid) or secret != str(raw_secret):
+        logger.warning(
+            "Creators credentials contained whitespace/invisible characters; "
+            "sanitized before OAuth request."
+        )
     url = config.TOKEN_URL
     version = config.CREATORS_VERSION
 


### PR DESCRIPTION

שורש הבאג (ולמה זה לא “2.1 מול 3.1”)
בדקתי מול ה‑SDK הרשמי של אמזון: ה‑scope וה‑Cognito endpoints שאנחנו משתמשים בהם נכונים (זהים ל‑SDK). לכן כשאתה מקבל {"error":"invalid_client"}, זה כמעט תמיד אומר שה‑Credential ID/Secret שנשלחים בפועל אינם בדיוק מה שאמזון מצפה.

הבאג הכי נפוץ במקרה שלך (ובעברית זה קורה הרבה) הוא ש‑copy/paste מוסיף תווי Unicode בלתי־נראים (LRM/RLM/ZWSP/NBSP). הם לא נראים בעין, אבל Cognito מתייחס אליהם כחלק מהסוד → ואז מקבלים invalid_client.

מה תיקנתי בקוד
הוספתי ניקוי בטוח של תווי whitespace/Unicode בלתי־נראים לפני בקשת ה‑OAuth, עם לוג אזהרה אם התבצע ניקוי (בלי לחשוף סודות):

/workspace/app/auth.py
Lines 42-56
```python 
_FORM_HEADERS = {"Content-Type": "application/x-www-form-urlencoded"}
 
# Some copy/paste sources (especially RTL languages) insert invisible Unicode
# marks or non-breaking spaces. Cognito then treats credentials as different
# strings and responds with {"error":"invalid_client"}.
_CRED_SANITIZE_RE = re.compile(
    r"[\s\u00A0\u200B\u200C\u200D\u200E\u200F\u202A-\u202E\u2066-\u2069\uFEFF]+"
)
 
def _sanitize_credential(value: str) -> str:
    if value is None:
        return ""
    value = unicodedata.normalize("NFKC", str(value))
    return _CRED_SANITIZE_RE.sub("", value)
```
/workspace/app/auth.py
Lines 114-125
```python 
def _fetch_token():
    raw_cid = config.CREATORS_CREDENTIAL_ID
    raw_secret = config.CREATORS_CREDENTIAL_SECRET
 
    cid = _sanitize_credential(raw_cid)
    secret = _sanitize_credential(raw_secret)
 
    if cid != str(raw_cid) or secret != str(raw_secret):
        logger.warning(
            "Creators credentials contained whitespace/invisible characters; "
            "sanitized before OAuth request."
        )
```
מה לעשות עכשיו
למשוך/לפרוס את העדכון האחרון ולנסות שוב.
אם בלוג תראה את ההודעה על “sanitized…” — זה מאשר שזה היה השורש.
אם עדיין invalid_client: זה כבר כמעט בוודאות זוג קרדנצ’לים לא נכון/לא פעיל (גם אם “נראה נכון” במסך), אבל לפחות הורדנו את בעיית התווים הבלתי־נראים.
לגבי “PAAPI is now available on Creators API”
זה לא בעיה. זו פשוט הודעת מיגרציה של אמזון: PA‑API “עובר” לפלטפורמת Creators API. הבוט שלך כבר עובד מול Creators API; זה לא אמור לגרום ל‑invalid_client (שזה שגיאת OAuth קרדנצ’לים).

<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Sanitize Creators API credentials to prevent `invalid_client` errors.

Invisible Unicode characters (e.g., LRM/RLM) can be introduced during copy-pasting, especially in RTL languages, causing Cognito to reject otherwise valid credentials. This change sanitizes the `client_id` and `client_secret` before the OAuth request.

---
<p><a href="https://cursor.com/agents/bc-7fd8f4b4-56c2-4562-993e-d5e73d935446"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7fd8f4b4-56c2-4562-993e-d5e73d935446"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->